### PR TITLE
Update openbsd_delver.sh

### DIFF
--- a/openbsd_delver.sh
+++ b/openbsd_delver.sh
@@ -2,7 +2,7 @@
 set -e
 
 PKG=$(pkg_info | grep -E '^(apache-ant|jdk|openal|maven|rsync|lwjgl|xz|gradle)\-' | wc -l)
-if [ "$PKG" -eq 8 ]
+if [ "$PKG" -ge 8 ]
 then
 	echo "Packages installed: OK"
 else
@@ -32,10 +32,11 @@ gradle DungeoneerDesktop:dist
 cd ..
 
 # extract
+rm -fr unjar
 mkdir unjar
 cd unjar
 GAME_FOLDER=$PWD
-/usr/local/jdk*/bin/jar xvf ../delver.jar
+/usr/local/jdk-1.*/bin/jar xvf ../delver.jar
 
 # remove java files
 rm -fr com/badlogic


### PR DESCRIPTION
it's possible to have 2 jdk versions installed, this would make problems with the package detection and also calling java using a wildcard in the path, resulting in calling twice the java binary in the same command.

Note that the -ge 8 isn't best option because if someone has 2 jdk installed and another package missing this will match... Maybe a better detection should be done.